### PR TITLE
Fix RTSP preview watchdog and telemetry

### DIFF
--- a/modules/frame_bus.py
+++ b/modules/frame_bus.py
@@ -34,6 +34,7 @@ class FrameBus:
         self._cond = threading.Condition(self._lock)
         self._info = FrameInfo()
         self._last_ts: Optional[float] = None
+        self._seq = 0
 
     # ------------------------------------------------------------------
     def put(self, frame: np.ndarray) -> None:
@@ -51,6 +52,7 @@ class FrameBus:
                 if dt > 0:
                     self._info.fps = 1.0 / dt
             self._last_ts = now
+            self._seq += 1
             self._cond.notify_all()
 
     # ------------------------------------------------------------------
@@ -70,3 +72,9 @@ class FrameBus:
         """Return the latest frame metadata."""
         with self._lock:
             return FrameInfo(self._info.w, self._info.h, self._info.fps)
+
+    @property
+    def seq(self) -> int:
+        """Return the last published sequence number."""
+        with self._lock:
+            return self._seq

--- a/modules/preview/mjpeg_publisher.py
+++ b/modules/preview/mjpeg_publisher.py
@@ -5,8 +5,8 @@ from collections import defaultdict
 from typing import AsyncIterator, Dict
 
 from modules.frame_bus import FrameBus
-from utils.jpeg import encode_jpeg
 from utils import logx
+from utils.jpeg import encode_jpeg
 
 
 class PreviewPublisher:
@@ -48,6 +48,12 @@ class PreviewPublisher:
                 frame = await asyncio.to_thread(bus.get_latest, 1000)
                 if frame is None:
                     continue
+                logx.event(
+                    "MJPEG_POP",
+                    camera_id=camera_id,
+                    topic=f"frames:preview:{camera_id}",
+                    seq=bus.seq,
+                )
                 jpeg = encode_jpeg(frame)
                 yield boundary + jpeg + b"\r\n"
         finally:

--- a/routers/cameras.py
+++ b/routers/cameras.py
@@ -113,7 +113,7 @@ def _init_preview_stream(cam: dict) -> None:
     except Exception:
         w, h = (640, 480)
     bus = FrameBus()
-    conn = RtspConnector(cam.get("url", ""), w, h)
+    conn = RtspConnector(cam.get("url", ""), w, h, camera_id=cam.get("id"))
     q = conn.subscribe()
 
     def _forward(q=q, bus=bus):


### PR DESCRIPTION
## Summary
- build and log ffmpeg RTSP command with timeout, low-latency flags
- add first-frame grace period, watchdog retry, and frame push/pop telemetry
- expose frame sequence numbers for MJPEG preview tracking

## Testing
- `pre-commit run --files modules/frame_bus.py modules/preview/mjpeg_publisher.py modules/stream/rtsp_connector.py routers/cameras.py`
- `pytest tests/test_frame_bus.py tests/test_mjpeg_publisher.py tests/test_dashboard_stream_preview.py tests/test_stream_frame_bus.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb940927e8832aab37a57bd2168e94