### PR TITLE
Refine RTSP FFmpeg reader with grace and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,11 @@ Edit `config.json` to set camera URLs, model paths, thresholds, and email settin
 
 - `FFPROBE_TIMEOUT_SEC` – Seconds to wait for RTSP metadata probes. Defaults to **30**.
 - `RTSP_STIMEOUT_USEC` – Microseconds for RTSP connect timeout passed as ``-stimeout``. Defaults to **5000000**.
+- `RTSP_FIRST_FRAME_GRACE_SEC` – Seconds to wait for the first frame before watchdog restarts. Defaults to **10**.
+- `RTSP_MAX_PARTIAL_READS` – Consecutive partial frame reads before reconnect. Defaults to **3**.
+- `FFMPEG_PROBESIZE` – Maximum bytes probed by FFmpeg. Defaults to **1000000**.
+- `FFMPEG_ANALYZEDURATION` – Stream analyze duration in microseconds. Defaults to **0**.
+- `FFMPEG_MAX_DELAY` – Maximum demuxer delay in microseconds. Defaults to **500000**.
 
 ### Entry/exit logging with PPE detection
 

--- a/modules/tracker/manager.py
+++ b/modules/tracker/manager.py
@@ -679,6 +679,8 @@ class PersonTracker:
         self.online = False
         self.restart_capture = False
         self.first_frame_ok = False
+        self.first_frame_grace = 0.0
+        self.capture_source = None
 
         self.renderer = None
         self.output_frame = None

--- a/modules/tracker/stream.py
+++ b/modules/tracker/stream.py
@@ -98,6 +98,7 @@ class CaptureWorker:
                     orientation=t.cfg.get("orientation", "vertical"),
                     pass_through=t.stream_mode == "lite",
                 )
+                t.capture_source = cap
                 cmd = getattr(cap, "pipeline", None) or getattr(cap, "cmd", None)
                 if isinstance(cmd, list):
                     cmd = " ".join(cmd)
@@ -116,6 +117,7 @@ class CaptureWorker:
                 )
                 fail_count = 0
                 max_failures = t.cfg.get("max_read_failures", 30)
+                t.first_frame_grace = time.time() + getattr(cap, "first_frame_grace", 0)
                 while t.running:
                     if t.restart_capture:
                         t.restart_capture = False
@@ -246,6 +248,7 @@ class CaptureWorker:
                         t.running = False
                         break
                 _shutdown_capture(cap)
+                t.capture_source = None
                 t.online = False
             except StreamUnavailable as e:
                 status = "timeout" if "timeout" in str(e).lower() else "error"
@@ -290,6 +293,7 @@ class CaptureWorker:
                 t.online = False
                 if cap:
                     _shutdown_capture(cap)
+                    t.capture_source = None
         log_event(
             CAPTURE_STOP,
             camera_id=t.cam_id,

--- a/scripts/rtsp_smoke.py
+++ b/scripts/rtsp_smoke.py
@@ -1,0 +1,36 @@
+import argparse
+import time
+from modules.capture.rtsp_ffmpeg import RtspFfmpegSource
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="RTSP smoke test")
+    parser.add_argument("url", help="RTSP URL")
+    parser.add_argument("--width", type=int, default=0)
+    parser.add_argument("--height", type=int, default=0)
+    args = parser.parse_args()
+    src = RtspFfmpegSource(
+        args.url,
+        width=args.width or None,
+        height=args.height or None,
+    )
+    src.open()
+    start = time.time()
+    frames = 0
+    first_latency = None
+    try:
+        while frames < 100:
+            frame = src.read(timeout=5)
+            frames += 1
+            if frames == 1:
+                first_latency = src.first_frame_ms or int((time.time() - start) * 1000)
+                print(f"FIRST_FRAME {first_latency}ms")
+        dur = time.time() - start
+        fps = frames / dur if dur > 0 else 0.0
+        print(f"Captured {frames} frames in {dur:.2f}s ({fps:.2f} FPS)")
+    finally:
+        src.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rtsp_reader_loop.py
+++ b/tests/test_rtsp_reader_loop.py
@@ -1,0 +1,86 @@
+import os
+import queue
+import threading
+import time
+
+import numpy as np
+
+from modules.capture.rtsp_ffmpeg import RtspFfmpegSource
+
+
+class FakeStdout:
+    def __init__(self, chunks):
+        self.chunks = list(chunks)
+
+    def readinto(self, mv):
+        if not self.chunks:
+            return 0
+        data = self.chunks.pop(0)
+        n = min(len(data), len(mv))
+        mv[:n] = data[:n]
+        if len(data) > n:
+            self.chunks.insert(0, data[n:])
+        return n
+
+    def close(self):
+        pass
+
+class FakeProc:
+    def __init__(self, chunks):
+        self.stdout = FakeStdout(chunks)
+        self.stderr = None
+
+
+def run_source(chunks, env=None):
+    old_env = {}
+    if env:
+        for k, v in env.items():
+            old_env[k] = os.environ.get(k)
+            os.environ[k] = v
+    src = RtspFfmpegSource("rtsp://example", width=2, height=1)
+    src.proc = FakeProc(chunks)
+    src._stop_event = threading.Event()
+
+    class AutoStopQueue(queue.Queue):
+        def __init__(self):
+            super().__init__(maxsize=1)
+
+        def put_nowait(self, item):
+            super().put_nowait(item)
+            src._stop_event.set()
+
+    src._frame_queue = AutoStopQueue()
+    src._start_proc = lambda: None
+    src._backoff.next = lambda: 0
+    t = threading.Thread(target=src._reader_loop, daemon=True)
+    t.start()
+    frame = None
+    try:
+        frame = src._frame_queue.get(timeout=1)
+    except queue.Empty:
+        src._stop_event.set()
+    t.join(timeout=1)
+    if env:
+        for k, v in old_env.items():
+            if v is None:
+                del os.environ[k]
+            else:
+                os.environ[k] = v
+    return src, frame
+
+
+def test_partial_read_accumulates():
+    chunks = [b"abc", b"def"]  # 6 bytes total for 2x1 frame
+    src, frame = run_source(chunks, {"RTSP_FIRST_FRAME_GRACE_SEC": "0"})
+    assert frame is not None
+    assert src.frames_total == 1
+    assert src.partial_reads == 0
+    np.testing.assert_array_equal(frame, np.array([[[97, 98, 99], [100, 101, 102]]], dtype=np.uint8))
+
+
+def test_eof_counts_partial_and_restart(monkeypatch):
+    monkeypatch.setattr("modules.capture.rtsp_ffmpeg.FIRST_FRAME_GRACE_SEC", 0)
+    monkeypatch.setattr("modules.capture.rtsp_ffmpeg.MAX_PARTIAL_READS", 1)
+    chunks = [b"abc"]  # EOF before full frame
+    src, _ = run_source(chunks)
+    assert src.partial_reads == 1


### PR DESCRIPTION
## Summary
- accumulate RTSP reads until a full frame, track partials and first-frame latency
- gate tracker restarts with a first-frame grace period and expose capture metrics
- add RTSP smoke test script and document new tuning environment variables

## Testing
- `python -m pytest tests/test_rtsp_reader_loop.py -q`
- `python -m pytest tests/test_rtsp_ffmpeg_source.py tests/test_rtsp_ffmpeg_probe.py tests/test_tracker_watchdog.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc00d779f0832a803893205774e1f6