### PR TITLE
Simplify refresh_flags to synchronous call

### DIFF
--- a/core/camera_manager.py
+++ b/core/camera_manager.py
@@ -151,13 +151,10 @@ class CameraManager:
 
         asyncio.create_task(_do_restart())
 
-    async def refresh_flags(self, camera_id: int) -> None:
-        async def _refresh() -> None:
-            tr = self.trackers.get(camera_id)
-            if tr:
-                tr.restart_capture = True
-
-        asyncio.create_task(_refresh())
+    def refresh_flags(self, camera_id: int) -> None:
+        tr = self.trackers.get(camera_id)
+        if tr:
+            tr.restart_capture = True
 
     @staticmethod
     def _cap_frame(frame: np.ndarray) -> np.ndarray:

--- a/docs/modules/modules_camera_manager.md
+++ b/docs/modules/modules_camera_manager.md
@@ -11,7 +11,7 @@ The implementation lives in ``core.camera_manager``.
 ## Key Functions
 - **start(camera_id)** – start trackers for the given camera.
 - **restart(camera_id)** – restart trackers and update status in Redis.
--- **refresh_flags(camera_id)** – signal a tracker to reload debug flags.
+- **refresh_flags(camera_id)** – synchronously signal a tracker to reload debug flags.
 
 ## Configuration Notes
 `CameraManager` receives callback functions for starting and stopping trackers.


### PR DESCRIPTION
## Summary
- remove nested coroutine and make `refresh_flags` synchronous
- document synchronous flag refresh

## Testing
- `pytest -q` *(fails: AttributeError: module 'main' has no attribute 'get_sync_client'; 35 failed, 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd077a1120832a872abeef6724dcef