### PR TITLE
Refactor camera restart sequence

### DIFF
--- a/core/camera_manager.py
+++ b/core/camera_manager.py
@@ -144,12 +144,18 @@ class CameraManager:
             f"transport={cam.get('rtsp_transport')} flags={flags}"
         )
 
-        async def _do_restart() -> None:
+        try:
             await asyncio.to_thread(self.stop_tracker_fn, camera_id, self.trackers)
-            if cam.get("enabled", True) and self.cfg.get("enable_person_tracking", True):
-                await self._attempt_start(cam)
+        except Exception:
+            logger.exception(f"[proc:{camera_id}] tracker stop failed")
+            raise
 
-        asyncio.create_task(_do_restart())
+        if cam.get("enabled", True) and self.cfg.get("enable_person_tracking", True):
+            try:
+                await self._attempt_start(cam)
+            except Exception:
+                logger.exception(f"[proc:{camera_id}] tracker start failed")
+                raise
 
     async def refresh_flags(self, camera_id: int) -> None:
         async def _refresh() -> None:


### PR DESCRIPTION
## Summary
- replace nested coroutine in `CameraManager.restart` with sequential awaits
- log and propagate tracker stop/start errors

## Testing
- `python3 -m pre_commit run --files core/camera_manager.py`
- `python3 -m pytest` *(fails: 35 failed, 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd07767820832aa4df580c2b6d62ef