### PR TITLE
refactor: simplify camera types

### DIFF
--- a/core/tracker_manager.py
+++ b/core/tracker_manager.py
@@ -143,7 +143,7 @@ def load_cameras(r: redis.Redis, default_url: str) -> List[dict]:
             for cam in cams:
                 cam["tasks"] = normalize_tasks(cam.get("tasks"))
                 cam.pop("mode", None)
-                cam.setdefault("type", "http")
+                cam.setdefault("type", "rtsp")
                 cam.setdefault("reverse", False)
                 cam.setdefault("line_orientation", "vertical")
                 cam.setdefault("orientation", "vertical")

--- a/models/camera.py
+++ b/models/camera.py
@@ -11,11 +11,6 @@ from typing import Any, Optional
 from utils.redis import get_sync_client
 
 
-class CameraProfile(str, Enum):
-    main = "main"
-    sub = "sub"
-
-
 class Orientation(str, Enum):
     horizontal = "horizontal"
     vertical = "vertical"
@@ -31,8 +26,8 @@ class Transport(str, Enum):
 class Camera:
     id: str
     name: str
-    type: str
     url: str
+    type: str = "rtsp"
     analytics: dict[str, bool] = field(default_factory=dict)
     line: Optional[list[int]] = None
     orientation: Orientation = Orientation.vertical
@@ -40,7 +35,6 @@ class Camera:
     resolution: Optional[str] = None
     reverse: bool = False
     show: bool = False
-    profile: Optional[CameraProfile] = None
     site_id: Optional[str] = None
     enabled: bool = True
     archived: bool = False
@@ -63,7 +57,6 @@ def _serialize(cam: Camera) -> dict[str, Any]:
         "resolution": cam.resolution,
         "reverse": cam.reverse,
         "show": cam.show,
-        "profile": cam.profile.value if cam.profile else None,
         "site_id": cam.site_id,
         "enabled": cam.enabled,
         "archived": cam.archived,
@@ -78,8 +71,8 @@ def _deserialize(data: dict[str, Any]) -> Camera:
     return Camera(
         id=data["id"],
         name=data["name"],
-        type=data["type"],
         url=data["url"],
+        type=data.get("type", "rtsp"),
         analytics=data.get("analytics") or {},
         line=data.get("line"),
         orientation=Orientation(data["orientation"]),
@@ -87,7 +80,6 @@ def _deserialize(data: dict[str, Any]) -> Camera:
         resolution=data.get("resolution"),
         reverse=data.get("reverse", False),
         show=data.get("show", False),
-        profile=CameraProfile(data["profile"]) if data.get("profile") else None,
         site_id=data.get("site_id"),
         enabled=data.get("enabled", True),
         archived=data.get("archived", False),

--- a/modules/camera_factory.py
+++ b/modules/camera_factory.py
@@ -7,12 +7,7 @@ import json
 import logging
 from typing import Any
 
-from modules.capture import (
-    FrameSourceError,
-    HttpMjpegSource,
-    IFrameSource,
-    RtspFfmpegSource,
-)
+from modules.capture import FrameSourceError, IFrameSource, RtspFfmpegSource
 
 try:  # pragma: no cover - optional gstreamer source
     from modules.capture import RtspGstSource  # type: ignore
@@ -134,11 +129,6 @@ async def async_open_capture(
     if transport is None:
         transport = "tcp" if cam_cfg.get("tcp", True) else "udp"
 
-    if src_type == "http":
-        max_queue = capture_buffer or cam_cfg.get("max_queue", 1)
-        cap = HttpMjpegSource(str(src), cam_id=cam_id, max_queue=max_queue)
-        await asyncio.to_thread(cap.open)
-        return cap, transport
     if src_type != "rtsp":
         raise StreamUnavailable(f"unknown mode {src_type}")
 

--- a/modules/capture/__init__.py
+++ b/modules/capture/__init__.py
@@ -1,7 +1,6 @@
 """Unified capture sources."""
 
 from .base import Backoff, FrameSourceError, IFrameSource
-from .http_mjpeg import HttpMjpegSource
 from .pipeline_ffmpeg import FfmpegPipeline
 from .rtsp_ffmpeg import RtspFfmpegSource
 
@@ -10,6 +9,5 @@ __all__ = [
     "FrameSourceError",
     "Backoff",
     "RtspFfmpegSource",
-    "HttpMjpegSource",
     "FfmpegPipeline",
 ]

--- a/modules/tracker/manager.py
+++ b/modules/tracker/manager.py
@@ -30,7 +30,6 @@ from utils import logx
 from utils.gpu import get_device
 from utils.redis import EVENTS_STREAM, get_sync_client, xadd_event
 from utils.time import format_ts
-from utils.url import get_stream_type
 
 from ..duplicate_filter import DuplicateFilter
 from ..utils import SNAP_DIR, lock
@@ -625,7 +624,7 @@ class PersonTracker:
         self.pipeline = cfg.get("pipeline", "")
         self.cam_id = cam_id
         self.src = src
-        self.src_type = src_type or cfg.get("type") or get_stream_type(src)
+        self.src_type = src_type or cfg.get("type") or "rtsp"
         self.classes = classes
         self.tasks = tasks or ["in_count", "out_count"]
         self.count_classes = cfg.get("count_classes", [])

--- a/static/js/camera_create.js
+++ b/static/js/camera_create.js
@@ -5,8 +5,6 @@ document.addEventListener("DOMContentLoaded", () => {
     document.getElementById(id) || (alt ? document.getElementById(alt) : null);
   const nameEl = getEl("name", "camName");
   const urlEl = getEl("url", "camUrl");
-  const typeEl = getEl("type", "camType");
-  const profileEl = getEl("profile", "camProfile");
   const orientationEl = getEl("orientation", "camLocation");
   const resolutionEl = getEl("resolution", "camRes");
   const transportEl = getEl("transport", "camStreamType");
@@ -37,7 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   let previewUrl = null;
 
-  const allowedSchemes = ["rtsp:", "http:", "https:", "rtmp:", "srt:"];
+  const allowedSchemes = ["rtsp:"];
 
   function mask(text) {
     return text.replace(/(?<=:\/\/)([^:@\s]+):([^@\/\s]+)@/g, "***:***@");
@@ -104,8 +102,6 @@ document.addEventListener("DOMContentLoaded", () => {
       return {
         name: nameEl?.value.trim(),
         url: urlEl?.value.trim(),
-        type: typeEl?.value,
-        profile: profileEl?.value,
         orientation: orientationEl?.value,
         resolution: resolutionEl?.value,
         transport: transportEl?.value || undefined,

--- a/templates/camera_create.html
+++ b/templates/camera_create.html
@@ -52,23 +52,7 @@
           <div class="invalid-feedback"></div>
         </div>
         <div class="row g-3 mb-3">
-          <div class="col-md-3">
-            <label for="type" class="form-label">Type</label>
-            <select id="type" name="type" class="form-select">
-              <option value="rtsp">RTSP</option>
-              <option value="http">HTTP</option>
-            </select>
-            <div class="invalid-feedback"></div>
-          </div>
-          <div class="col-md-3">
-            <label for="profile" class="form-label">Profile</label>
-            <select id="profile" name="profile" class="form-select">
-              <option value="main">Main</option>
-              <option value="sub">Sub</option>
-            </select>
-            <div class="invalid-feedback"></div>
-          </div>
-          <div class="col-md-2">
+          <div class="col-md-4">
             <label for="orientation" class="form-label">Orientation</label>
             <select id="orientation" name="orientation" class="form-select">
               <option value="vertical">Vertical</option>
@@ -76,7 +60,7 @@
             </select>
             <div class="invalid-feedback"></div>
           </div>
-          <div class="col-md-2">
+          <div class="col-md-4">
             <label for="resolution" class="form-label">Resolution</label>
             <select id="resolution" name="resolution" class="form-select">
               <option value="original">Original</option>
@@ -86,7 +70,7 @@
             </select>
             <div class="invalid-feedback"></div>
           </div>
-          <div class="col-md-2">
+          <div class="col-md-4">
             <label for="transport" class="form-label">Transport</label>
             <select id="transport" name="transport" class="form-select">
               <option value="">Auto</option>

--- a/templates/cameras.html
+++ b/templates/cameras.html
@@ -18,7 +18,7 @@
     <a href="/cameras/add" class="btn btn-primary mb-4">Add Camera</a>
     <div class="table-responsive">
         <table class="table table-bordered">
-        <thead><tr><th>ID</th><th>Name</th><th>Type</th><th>URL</th><th>Status</th><th>PPE</th><th>VMS</th><th>In/Out Count</th><th>Line</th><th>Orientation</th><th>Transport</th><th>Res</th><th>Rev</th><th>Enabled</th><th>Show</th><th>Actions</th></tr></thead>
+        <thead><tr><th>ID</th><th>Name</th><th>URL</th><th>Status</th><th>PPE</th><th>VMS</th><th>In/Out Count</th><th>Line</th><th>Orientation</th><th>Transport</th><th>Res</th><th>Rev</th><th>Enabled</th><th>Show</th><th>Actions</th></tr></thead>
 
 
         <tbody id="camBody">
@@ -26,7 +26,6 @@
         <tr data-id="{{c.id}}">
             <td class="col-id">{{c.id}}</td>
             <td class="col-name">{{c.name}}</td>
-            <td class="col-type">{{c.type}}</td>
             <td class="col-url">{{c.url}}</td>
             <td class="col-status">
                 {% if c.online %}

--- a/tests/camera_form_payload_contract.test.js
+++ b/tests/camera_form_payload_contract.test.js
@@ -14,9 +14,7 @@ test('camera form payload matches API schema', () => {
     reverse: false,
     show: false,
     enabled: false,
-    profile: null,
-    site_id: null,
-    type: 'rtsp'
+    site_id: null
   });
 
   const expected = [
@@ -30,9 +28,7 @@ test('camera form payload matches API schema', () => {
     'reverse',
     'show',
     'enabled',
-    'profile',
-    'site_id',
-    'type'
+    'site_id'
   ];
 
   const payload = buildPayload();

--- a/tests/test_camera_add_flow.py
+++ b/tests/test_camera_add_flow.py
@@ -56,6 +56,6 @@ def test_camera_add_flow(client, monkeypatch):
     assert DummyStream.kwargs["frame_skip"] == 1
     assert r.json()["notes"].startswith("/api/cameras/preview?token=")
 
-    resp = client.post("/cameras", json={"name": "Cam1", "url": "rtsp://demo", "type": "rtsp"})
+    resp = client.post("/cameras", json={"name": "Cam1", "url": "rtsp://demo"})
     assert resp.status_code == 200
     assert any(c["name"] == "Cam1" for c in cameras.cams)

--- a/tests/test_camera_api_create.py
+++ b/tests/test_camera_api_create.py
@@ -46,7 +46,6 @@ def _payload():
     return {
         "name": "Cam",
         "url": "rtsp://user:pass@example.com/stream",
-        "profile": "recording",
         "orientation": "horizontal",
         "show": True,
         "transport": "udp",

--- a/tests/test_camera_db.py
+++ b/tests/test_camera_db.py
@@ -65,7 +65,7 @@ def test_camera_record_persist_and_defaults(monkeypatch):
 
     class DummyReq:
         async def json(self):
-            return {"name": "CamDB", "url": "rtsp://demo", "type": "rtsp"}
+            return {"name": "CamDB", "url": "rtsp://demo"}
 
     class DummyManager:
         async def start(self, cam_id):

--- a/tests/test_camera_manager_online_status.py
+++ b/tests/test_camera_manager_online_status.py
@@ -9,7 +9,7 @@ from core.camera_manager import CameraManager
 def test_start_tracker_sets_redis_online():
     r = fakeredis.FakeRedis(decode_responses=True)
     trackers = {}
-    cams = [{"id": 1, "url": "", "type": "http", "tasks": []}]
+    cams = [{"id": 1, "url": "", "type": "rtsp", "tasks": []}]
 
     def start_tracker(cam, cfg, trackers_map, redis, cb=None):
         tr = SimpleNamespace(online=True)

--- a/tests/test_camera_probe_api.py
+++ b/tests/test_camera_probe_api.py
@@ -49,7 +49,6 @@ def client() -> TestClient:
             "/cameras/probe",
             {
                 "name": "cam1",
-                "type": "RTSP",
                 "url": "rtsp://example",
                 "transport": "TCP",
                 "timeout_sec": 8,
@@ -121,7 +120,6 @@ def test_probe_endpoints(
 def test_camera_probe_bad_url(client: TestClient):
     body = {
         "name": "cam1",
-        "type": "RTSP",
         "url": "http://example",  # not rtsp
         "transport": "TCP",
         "timeout_sec": 5,

--- a/tests/test_camera_schema.py
+++ b/tests/test_camera_schema.py
@@ -1,14 +1,14 @@
 import pytest
 from pydantic import ValidationError
 
-from schemas.camera import CameraCreate, CameraType, CameraUpdate, Orientation, Point
+from schemas.camera import CameraCreate, CameraUpdate, Orientation, Point
 
 
 def test_url_type_validation():
     cam = CameraCreate(name="c1", url="rtsp://example")
-    assert cam.type == CameraType.rtsp
+    assert cam.type == "rtsp"
     with pytest.raises(ValidationError):
-        CameraCreate(name="c2", url="http://example", type=CameraType.rtsp)
+        CameraCreate(name="c2", url="http://example")
 
 
 def test_line_optional_for_counting():
@@ -59,12 +59,12 @@ def test_update_uses_same_validation():
 def test_camera_happy_path():
     cam = CameraCreate(name="ok", url="rtsp://a", line=[Point(x=0, y=0), Point(x=1, y=1)])
     assert cam.orientation is Orientation.vertical
-    assert cam.type == CameraType.rtsp
+    assert cam.type == "rtsp"
 
 
 def test_bad_url_raises_error():
     with pytest.raises(ValidationError):
-        CameraCreate(name="c1", url="ftp://bad", type=CameraType.rtsp)
+        CameraCreate(name="c1", url="ftp://bad")
 
 
 def test_invalid_orientation_enum():

--- a/utils/url.py
+++ b/utils/url.py
@@ -41,29 +41,6 @@ def normalize_stream_url(url: str) -> str:
     return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
-def get_stream_type(url: str) -> str:
-    """Return stream type based on the URL scheme.
-
-    Parameters
-    ----------
-    url: str
-        Source string representing the camera stream.
-
-    Returns
-    -------
-    str
-        ``"rtsp"`` when the URL starts with ``rtsp://`` and ``"http"`` when it
-        begins with ``http://`` or ``https://``. A :class:`ValueError` is raised
-        for any other scheme.
-    """
-    lowered = url.lower()
-    if lowered.startswith("rtsp://"):
-        return "rtsp"
-    if lowered.startswith("http://") or lowered.startswith("https://"):
-        return "http"
-    raise ValueError("unsupported url scheme")
-
-
 _CRED_RE = re.compile(r"(?<=://)([^:@\s]+):([^@/\s]+)@")
 
 


### PR DESCRIPTION
## Summary
- drop type/profile UI elements and schema fields
- default backend camera type to rtsp and remove HTTP capture
- clean up helpers, utilities, and tests for single rtsp type

## Testing
- `pytest` *(fails: ModuleNotFoundError and failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1bb65d94832aa0ce820ba637ec66