### PR TITLE
refactor: simplify capture factory

### DIFF
--- a/core/camera_manager.py
+++ b/core/camera_manager.py
@@ -39,7 +39,11 @@ class CameraManager:
         self._state: Dict[int, RetryState] = {}
         self._latest_frames: Dict[int, Dict[str, object]] = {}
         self._latest_lock = asyncio.Lock()
-        self._loop = asyncio.get_event_loop()
+        try:
+            self._loop = asyncio.get_event_loop()
+        except RuntimeError:
+            self._loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self._loop)
 
     def _get_state(self, cam_id: int) -> RetryState:
         return self._state.setdefault(cam_id, RetryState())
@@ -205,7 +209,7 @@ class CameraManager:
         try:
             cap_cfg = CaptureConfig(uri=url)
             cap, _ = await async_open_capture(
-                self.cfg, cap_cfg, cam_id, cam.get("type") if cam else None
+                self.cfg, cap_cfg, cam_id
             )
             try:
                 res = await asyncio.to_thread(cap.read, timeout)

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from server.config import _load_secret_key
 from server.startup import handle_unexpected_error
 from server.startup import init_app as _init_app
 from server.startup import lifespan
+from utils.redis import get_sync_client as _get_sync_client
 
 
 def init_app(
@@ -26,6 +27,11 @@ def init_app(
     workers: int | None = None,
 ):
     return _init_app(app, config_path=config_path, stream_url=stream_url, workers=workers)
+
+
+def get_sync_client(url: str | None = None):
+    """Expose sync Redis client for tests."""
+    return _get_sync_client(url)
 
 
 try:  # pragma: no cover - middleware optional

--- a/modules/camera_factory.py
+++ b/modules/camera_factory.py
@@ -114,8 +114,6 @@ async def async_open_capture(
     cfg: dict[str, Any],
     cap_cfg: CaptureConfig,
     cam_id: int | None = None,
-    src_type: str | None = None,
-    use_gpu: bool = False,
     **kwargs: Any,
 ) -> tuple[IFrameSource, str]:
     """Asynchronously instantiate and open a frame source."""
@@ -123,15 +121,13 @@ async def async_open_capture(
     cam_cfg = cfg.get("camera", {})
     cam_id = cam_id if cam_id is not None else 0
     src = cap_cfg.uri if cap_cfg.uri is not None else cam_cfg.get("uri", "")
-    if src_type is None:
-        src_type = cam_cfg.get("mode", "rtsp")
+    src_type = cam_cfg.get("mode", "rtsp")
 
     transport = cap_cfg.transport
     width, height = (None, None)
     if cap_cfg.resolution and len(cap_cfg.resolution) == 2:
         width, height = cap_cfg.resolution
     latency = _clamp_latency(cap_cfg.latency_ms)
-    capture_buffer = kwargs.pop("capture_buffer", None)
     if src_type == "rtsp" and transport is None and isinstance(src, str):
         try:
             probed_url, transport, w_p, h_p, _ = await async_probe_rtsp(src)
@@ -183,8 +179,6 @@ def open_capture(
     cfg: dict[str, Any],
     cap_cfg: CaptureConfig,
     cam_id: int | None = None,
-    src_type: str | None = None,
-    use_gpu: bool = False,
     **kwargs: Any,
 ) -> tuple[IFrameSource, str]:
     """Instantiate and open a frame source synchronously.
@@ -197,8 +191,6 @@ def open_capture(
             cfg,
             cap_cfg,
             cam_id,
-            src_type,
-            use_gpu,
             **kwargs,
         )
     )


### PR DESCRIPTION
## Summary
- remove `src_type` and `use_gpu` parameters from camera factory helpers
- adjust capture consumers to match new API and improve event loop setup
- expose Redis client helper for tests

## Testing
- `pytest tests/test_camera_factory.py`
- `pytest tests/test_camera_factory.py tests/test_camera_start_tracker_async.py` *(fails: Internal Server Error in camera routes)*

------
https://chatgpt.com/codex/tasks/task_e_68bd28a1025c832aa5bb5494646f07c3