### PR TITLE
Allow viewer role to access camera previews

### DIFF
--- a/routers/blueprints.py
+++ b/routers/blueprints.py
@@ -81,3 +81,5 @@ def register_blueprints(app: FastAPI) -> None:
     """Attach all routers to the given FastAPI app."""
     for mod in MODULES:
         app.include_router(mod.router)
+        if mod is cam_routes and hasattr(mod, "preview_router"):
+            app.include_router(mod.preview_router)

--- a/tests/test_camera_mjpeg.py
+++ b/tests/test_camera_mjpeg.py
@@ -1,4 +1,5 @@
-import asyncio
+from fastapi import FastAPI
+from starlette.testclient import TestClient
 
 from routers import cameras
 
@@ -9,9 +10,23 @@ def setup_function():
     cameras.rtsp_connectors = {}
 
 
-def test_mjpeg_stream(monkeypatch):
+def _build_app():
+    app = FastAPI()
+    app.include_router(cameras.router)
+    app.include_router(cameras.preview_router)
+    return app
+
+
+def test_mjpeg_stream_viewer_role(monkeypatch):
     cameras.cams = [{"id": 1, "url": "rtsp://example/stream"}]
-    monkeypatch.setattr(cameras, "require_roles", lambda *a, **k: None)
+
+    calls = []
+
+    def fake_require_roles(request, roles):
+        calls.append(roles)
+        return {"role": "viewer"}
+
+    monkeypatch.setattr(cameras, "require_roles", fake_require_roles)
 
     class FakePub:
         def __init__(self):
@@ -32,21 +47,26 @@ def test_mjpeg_stream(monkeypatch):
 
     cameras.preview_publisher = FakePub()
 
-    async def _run():
-        resp = await cameras.camera_mjpeg(1)
+    app = _build_app()
+    with TestClient(app) as client:
+        resp = client.get("/api/cameras/1/mjpeg")
         assert resp.status_code == 200
-        gen = resp.body_iterator
-        first = await gen.__anext__()
-        second = await gen.__anext__()
-        assert b"A" in first and b"B" in second
-        await gen.aclose()
+        body = resp.content
+        assert b"A" in body and b"B" in body
 
-    asyncio.run(_run())
+    assert calls == [["viewer", "admin"]]
 
 
-def test_show_hide_and_stats(monkeypatch):
+def test_viewer_can_toggle_preview(monkeypatch):
     cameras.cams = [{"id": 1, "url": "rtsp://example/stream"}]
-    monkeypatch.setattr(cameras, "require_roles", lambda *a, **k: None)
+
+    calls = []
+
+    def fake_require_roles(request, roles):
+        calls.append(roles)
+        return {"role": "viewer"}
+
+    monkeypatch.setattr(cameras, "require_roles", fake_require_roles)
 
     class FakePub:
         def __init__(self):
@@ -66,33 +86,13 @@ def test_show_hide_and_stats(monkeypatch):
 
     cameras.preview_publisher = FakePub()
 
-    class FakeConn:
-        def __init__(self):
-            self.started = 0
-            self.stopped = 0
+    app = _build_app()
+    with TestClient(app) as client:
+        resp = client.post("/api/cameras/1/show")
+        assert resp.status_code == 200
+        assert resp.json()["showing"] is True
+        resp2 = client.post("/api/cameras/1/hide")
+        assert resp2.status_code == 200
+        assert resp2.json()["showing"] is False
 
-        def start(self):
-            self.started += 1
-
-        def stop(self):
-            self.stopped += 1
-
-        def stats(self):
-            return {"state": "ok"}
-
-    fake_conn = FakeConn()
-    cameras.rtsp_connectors = {1: fake_conn}
-
-    async def _run():
-        await cameras.camera_show(1)
-        assert cameras.preview_publisher.is_showing(1)
-        stats = await cameras.camera_stats(1)
-        assert stats["preview"] is True
-        assert stats["state"] == "ok"
-        await cameras.camera_hide(1)
-        assert not cameras.preview_publisher.is_showing(1)
-        stats2 = await cameras.camera_stats(1)
-        assert stats2["preview"] is False
-        assert fake_conn.started == 0 and fake_conn.stopped == 0
-
-    asyncio.run(_run())
+    assert calls == [["viewer", "admin"], ["viewer", "admin"]]


### PR DESCRIPTION
## Summary
- expose camera preview endpoints to viewer role via dedicated sub-router
- include preview routes during blueprint registration
- test that viewers can stream MJPEG feeds and toggle previews

## Testing
- `pre-commit run --files routers/cameras.py routers/blueprints.py tests/test_camera_mjpeg.py`
- `pytest tests/test_camera_mjpeg.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd2b0a552c832ab13b8b0511d579f3