### PR TITLE
Fix dashboard MJPEG feed URLs

### DIFF
--- a/static/js/mjpeg_feed.js
+++ b/static/js/mjpeg_feed.js
@@ -1,14 +1,26 @@
 (function(){
+  function startFeed(img){
+    const cam = img.dataset.cam;
+    if(!cam) return;
+    fetch(`/api/cameras/${cam}/show`,{method:'POST'}).catch(e=>console.error('show',e));
+    img.src = `/api/cameras/${cam}/mjpeg`;
+    const modal = img.closest('.modal');
+    if(modal){
+      modal.addEventListener('hidden.bs.modal',()=>{
+        fetch(`/api/cameras/${cam}/hide`,{method:'POST'}).catch(e=>console.error('hide',e));
+        img.removeAttribute('src');
+      },{once:true});
+    }
+  }
   function initMjpegFeeds(root=document){
-    root.querySelectorAll('img.feed-img').forEach(img=>{img.src='/camera';});
-
+    root.querySelectorAll('img.feed-img').forEach(startFeed);
   }
-  if (typeof module !== "undefined") {
-    module.exports = { initMjpegFeeds };
-  } else {
-    globalThis.initMjpegFeeds = initMjpegFeeds;
+  if(typeof module!=='undefined'){
+    module.exports={initMjpegFeeds};
+  }else{
+    globalThis.initMjpegFeeds=initMjpegFeeds;
   }
-  if (typeof document !== "undefined" && !globalThis.__TEST__) {
+  if(typeof document!=='undefined' && !globalThis.__TEST__){
     initMjpegFeeds();
   }
 })();

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -156,7 +156,7 @@
                         {{cam.name}}
                       </div>
                       <div class="feed-container">
-                        <img class="card-img-top feed-img" src="/camera" alt="feed">
+                        <img class="card-img-top feed-img" data-cam="{{ cam.id }}" src="{{ url_for('camera_mjpeg', camera_id=cam.id) }}" alt="feed">
 
                       </div>
 
@@ -262,7 +262,7 @@
         {% if cameras %}
         {% set cam = cameras[0] %}
         <div class="col-md-2">
-            <img class="img-fluid feed-img" src="/camera" alt="feed">
+            <img class="img-fluid feed-img" data-cam="{{ cam.id }}" src="{{ url_for('camera_mjpeg', camera_id=cam.id) }}" alt="feed">
         </div>
         {% endif %}
 


### PR DESCRIPTION
## Summary
- point dashboard camera feeds to their `/api/cameras/{id}/mjpeg` endpoints
- start/stop MJPEG previews for each feed via `mjpeg_feed.js`

## Testing
- `npm test` *(fails: tests/camera_create_test_status.test.js)*
- `pytest tests/test_dashboard_stream_preview.py tests/test_dashboard_stream_cleanup.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd634d584c832a98bdc4e8f3ca4932