### PR TITLE
Remove visitor management flag from camera settings

### DIFF
--- a/core/camera_manager.py
+++ b/core/camera_manager.py
@@ -92,7 +92,6 @@ class CameraManager:
         return {
             "enabled": cam.get("enabled", True),
             "ppe": cam.get("ppe", False),
-            "vms": cam.get("visitor_mgmt", False),
             "counting": any(t in cam.get("tasks", []) for t in ("in_count", "out_count")),
         }
 
@@ -209,7 +208,9 @@ class CameraManager:
         try:
             cap_cfg = CaptureConfig(uri=url)
             cap, _ = await async_open_capture(
-                self.cfg, cap_cfg, cam_id
+                self.cfg,
+                cap_cfg,
+                cam_id,
             )
             try:
                 res = await asyncio.to_thread(cap.read, timeout)


### PR DESCRIPTION
## Summary
- drop `vms`/`visitor_mgmt` flag from camera manager settings

## Testing
- `pre-commit run --files core/camera_manager.py`
- `pytest` *(fails: 69 failed, 146 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9da21ba8832a8b4fd053509cdef6