### PR TITLE
fix(troubleshooter): publish camera:{id}:last_frame_ts to Redis on each frame so UI no longer reports 'stream: no frame'

### DIFF
--- a/core/camera_manager.py
+++ b/core/camera_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from typing import Callable, Dict, Iterable
 
 import numpy as np
@@ -182,6 +183,11 @@ class CameraManager:
     async def _update_latest(self, cam_id: int, frame: np.ndarray) -> None:
         async with self._latest_lock:
             self._latest_frames[cam_id] = {"ts": mtime(), "bgr": frame.copy()}
+            if self.redis:
+                try:
+                    self.redis.set(f"camera:{cam_id}:last_frame_ts", str(time.time()))
+                except Exception:
+                    pass
 
     def update_latest_frame(self, cam_id: int, frame: np.ndarray) -> None:
         """Schedule update of cached frame for ``cam_id``."""


### PR DESCRIPTION
## Summary
- update latest-frame cache to publish wall-clock timestamps to Redis, letting Troubleshooter detect active streams

## Testing
- `pre-commit run --files core/camera_manager.py`
- `pytest tests/test_camera_manager_helpers.py tests/test_camera_manager_injection.py tests/test_camera_manager_online_status.py -q` *(fails: CameraManager.__init__ mismatch; ffmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdacc230f8832aa8ceb363c0807535