### PR TITLE
Protect license key page with admin login

### DIFF
--- a/routers/settings.py
+++ b/routers/settings.py
@@ -473,13 +473,21 @@ async def reset_endpoint(ctx: SettingsContext = Depends(get_settings_context)):
 
 
 @router.get("/license")
-async def license_page(request: Request, ctx: SettingsContext = Depends(get_settings_context)):
+async def license_page(
+    request: Request,
+    ctx: SettingsContext = Depends(get_settings_context),
+    user: dict = Depends(require_admin),
+):
     """Render a page for entering a license key."""
     return ctx.templates.TemplateResponse("license.html", {"request": request, "cfg": ctx.cfg})
 
 
 @router.post("/license")
-async def activate_license(request: Request, ctx: SettingsContext = Depends(get_settings_context)):
+async def activate_license(
+    request: Request,
+    ctx: SettingsContext = Depends(get_settings_context),
+    user: dict = Depends(require_admin),
+):
     data = await request.json()
     key = data.get("key")
     from config.license_storage import set as save_license

--- a/tests/test_settings_routes.py
+++ b/tests/test_settings_routes.py
@@ -97,7 +97,13 @@ def test_misc_endpoints(tmp_path):
     assert asyncio.run(settings.reset_endpoint(ctx)) == {"reset": True}
 
     lic = generate_license("default_secret", 1, 1, {}, client="T")
-    resp = asyncio.run(settings.activate_license(DummyRequest(json_data={"key": lic}), ctx))
+    resp = asyncio.run(
+        settings.activate_license(
+            DummyRequest(json_data={"key": lic}),
+            ctx,
+            {"role": "admin"},
+        )
+    )
     assert resp["activated"]
     assert ctx.cfg["license_key"] == lic
 


### PR DESCRIPTION
## Summary
- require admin login for license entry and activation endpoints
- update settings route tests for new auth requirement

## Testing
- `python3 -m pre_commit run --files routers/settings.py tests/test_settings_routes.py`
- `python3 -m pytest tests/test_settings_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68be5e0bc87c832a949e5eba6b05d4a8