### PR TITLE
Allow unauthenticated license activation

### DIFF
--- a/routers/blueprints.py
+++ b/routers/blueprints.py
@@ -81,3 +81,6 @@ def register_blueprints(app: FastAPI) -> None:
         app.include_router(mod.router)
         if mod is cam_routes and hasattr(mod, "preview_router"):
             app.include_router(mod.preview_router)
+        # Include any module-defined unauthenticated/public router (e.g., license page)
+        if hasattr(mod, "public_router"):
+            app.include_router(mod.public_router)

--- a/routers/settings.py
+++ b/routers/settings.py
@@ -28,8 +28,9 @@ from schemas.alerts import EmailConfig
 
 # ruff: noqa: B008
 
-
 router = APIRouter(dependencies=[Depends(require_admin)])
+# Public routes that must not require authentication (e.g., license activation)
+public_router = APIRouter()
 BASE_DIR = Path(__file__).resolve().parent.parent
 LOGO_DIR = BASE_DIR / "static" / "logos"
 URL_RE = re.compile(r"^https?://")
@@ -472,13 +473,13 @@ async def reset_endpoint(ctx: SettingsContext = Depends(get_settings_context)):
     return {"reset": True}
 
 
-@router.get("/license")
+@public_router.get("/license")
 async def license_page(request: Request, ctx: SettingsContext = Depends(get_settings_context)):
     """Render a page for entering a license key."""
     return ctx.templates.TemplateResponse("license.html", {"request": request, "cfg": ctx.cfg})
 
 
-@router.post("/license")
+@public_router.post("/license")
 async def activate_license(request: Request, ctx: SettingsContext = Depends(get_settings_context)):
     data = await request.json()
     key = data.get("key")


### PR DESCRIPTION
## Summary
- expose `/license` activation routes on a public router without admin dependency
- include optional `public_router` when registering module routers

## Testing
- `python3 -m pre_commit run --files`
- `python3 -m pytest` *(fails: `test_trim_sorted_set_removes_old_entries` and others, includes Redis connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_68be5df0c7d8832aadeb1f1a4f8f2c30