### PR TITLE
Fix startup crash by including async-timeout dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,5 +6,6 @@ black==25.1.0
 isort==6.0.1
 pre-commit==4.3.0
 redis==6.4.0
+async-timeout
 psycopg[binary]==3.2.9
 pydantic==2.11.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ fastapi
 starlette
 uvicorn
 redis
+async-timeout
 fakeredis
 opencv-python-headless
 ultralytics


### PR DESCRIPTION
## Summary
- add missing async-timeout dependency required by redis async client

## Testing
- `python main.py`
- `pytest` *(fails: AttributeError, RuntimeError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68be98d04cf0832a9ff0e4a537a1465a