### PR TITLE
Fix MJPEG streaming and diagnostics

### DIFF
--- a/modules/preview/mjpeg_publisher.py
+++ b/modules/preview/mjpeg_publisher.py
@@ -41,7 +41,7 @@ class PreviewPublisher:
             return
         self._clients[camera_id] += 1
         logx.event("PREVIEW_CLIENT_OPEN", camera_id=camera_id)
-        boundary = b"--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+        boundary = b"--frame"
         try:
             while self.is_showing(camera_id):
                 frame = await bus.get_latest_async(1000)
@@ -54,7 +54,11 @@ class PreviewPublisher:
                     seq=bus.seq,
                 )
                 jpeg = encode_jpeg(frame)
-                yield boundary + jpeg + b"\r\n"
+                headers = (
+                    b"Content-Type: image/jpeg\r\n"
+                    + f"Content-Length: {len(jpeg)}\r\n\r\n".encode()
+                )
+                yield boundary + b"\r\n" + headers + jpeg + b"\r\n"
         finally:
             self._clients[camera_id] -= 1
             logx.event("PREVIEW_CLIENT_CLOSE", camera_id=camera_id)

--- a/routers/blueprints.py
+++ b/routers/blueprints.py
@@ -79,7 +79,7 @@ def register_blueprints(app: FastAPI) -> None:
     """Attach all routers to the given FastAPI app."""
     for mod in MODULES:
         app.include_router(mod.router)
-        if mod is cam_routes and hasattr(mod, "preview_router"):
+        if hasattr(mod, "preview_router"):
             app.include_router(mod.preview_router)
         # Include any module-defined unauthenticated/public router (e.g., license page)
         if hasattr(mod, "public_router"):

--- a/routers/troubleshooter.py
+++ b/routers/troubleshooter.py
@@ -18,6 +18,7 @@ from starlette.responses import StreamingResponse
 from diagnostics.registry import list_tests
 from modules import troubleshooter_runner as ts_runner
 from modules.stream_probe import check_rtsp
+from routers import cameras as cam_routes
 from utils.deps import get_cameras, get_templates
 
 router = APIRouter()
@@ -55,6 +56,13 @@ def _get_camera_mode(cam: Dict[str, Any]) -> str:
 
 
 async def get_last_frame_age_sec(cam_id: int) -> float | None:
+    bus = cam_routes._frame_buses.get(cam_id)
+    if bus is not None:
+        with bus._lock:
+            ts = bus._last_ts
+        if ts is not None:
+            return time.time() - ts
+        return None
     if redisfx is None:
         return None
     try:


### PR DESCRIPTION
## Summary
- Expose camera preview router alongside main routes
- Stream MJPEG frames with proper multipart headers
- Troubleshooter verifies fresh frames via FrameBus

## Testing
- `pre-commit run --files routers/blueprints.py modules/preview/mjpeg_publisher.py routers/troubleshooter.py`
- `pytest` *(fails: AttributeError in routers.cameras and others)*

------
https://chatgpt.com/codex/tasks/task_e_68be9ee85dac832ab53d61646a744efd