### PR TITLE
Fix timezone utils and parse range for consistency

### DIFF
--- a/utils/time.py
+++ b/utils/time.py
@@ -14,8 +14,16 @@ time = time
 
 
 def format_ts(ts: float, fmt: str = "%Y-%m-%d %H:%M:%S") -> str:
-    """Return formatted string for the given timestamp."""
-    tzname = shared_config.get("timezone", "Asia/Kolkata")
+    """Return formatted string for the given timestamp.
+
+    Defaults to UTC when no timezone is configured so that the
+    result is deterministic across environments. The previous
+    implementation used ``Asia/Kolkata`` as the fallback timezone,
+    which made `format_ts(0)` depend on the local environment and
+    broke tests expecting a UTC value.
+    """
+
+    tzname = shared_config.get("timezone", "UTC")
     tz = ZoneInfo(tzname)
     return datetime.fromtimestamp(ts, tz).strftime(fmt)
 
@@ -24,16 +32,21 @@ def parse_range(range_str: str) -> tuple[int, int]:
     """Return start and end timestamps for the given range string.
 
     The range string is case-insensitive and may be one of:
+
     - "today" or "1d": start of current day to now
     - "this_month" or "month": start of current month to now
     - anything else: last 7 days
     """
 
-    # Use naive datetime so callers can monkeypatch datetime.now in tests
-    now_dt = datetime.now()
-    now = int(now_dt.timestamp())
+    # Use time.time() so tests can monkeypatch it via utils.time.time
+    now = int(time.time())
+
+    tzname = shared_config.get("timezone", "UTC")
+    tz = ZoneInfo(tzname)
+    now_dt = datetime.fromtimestamp(now, tz)
     tf = (range_str if isinstance(range_str, str) else "7d").lower()
     today = now_dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
     if tf in {"today", "1d"}:
         start_ts = int(today.timestamp())
     elif tf in {"this_month", "month"}:


### PR DESCRIPTION
## Summary
- default `format_ts` to UTC for deterministic output
- use `time.time()` and configurable timezone in `parse_range`

## Testing
- `pytest tests/test_time_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68becba9da78832a8b091daeb740e1a1